### PR TITLE
mtl-2.1 support

### DIFF
--- a/data-lens-light.cabal
+++ b/data-lens-light.cabal
@@ -30,6 +30,6 @@ library
   build-depends:
     base >= 4.5 && < 5,
     template-haskell,
-    mtl >= 2.2
+    mtl >= 2.1
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Data/Lens/Light/State.hs
+++ b/src/Data/Lens/Light/State.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Data.Lens.Light.State
   ( access
   , (~=)
@@ -22,6 +23,12 @@ l ~= b = modify $ setL l b
 -- whole state.
 (!=) :: MonadState a m => Lens a b -> b -> m ()
 l != b = modify' $ setL l $! b
+
+#if !MIN_VERSION_mtl(2,2,0)
+-- Copied from mtl-2.2.0.1
+modify' :: MonadState s m => (s -> s) -> m ()
+modify' f = state (\s -> let s' = f s in s' `seq` ((), s'))
+#endif
 
 infixr 4 ~=, !=
 


### PR DESCRIPTION
This would make my life in Stackage a bit easier, since we're pinned down to transformers-0.3 for the moment due to loads of upper bounds. If you don't want the CPP overhead, I can conditionally restrict to the older data-lens-light instead.
