### PR TITLE
Relaxing base requirement

### DIFF
--- a/data-lens-light.cabal
+++ b/data-lens-light.cabal
@@ -28,7 +28,7 @@ library
     Data.Lens.Light.State
   -- other-extensions:    
   build-depends:
-    base >= 4.5 && < 5,
+    base == 4.*,
     template-haskell,
     mtl >= 2.1
   hs-source-dirs:      src


### PR DESCRIPTION
Is there a reason for base >= 4.5? I relaxed it to base == 4.\* instead. This allows me to build the package with ghc-7.0.4 and use it on older systems because there's no way I will be able to build the full-blown lens package.
